### PR TITLE
fix parser bug with in expr, ast for expr lists

### DIFF
--- a/antlr_plsql/plsql.g4
+++ b/antlr_plsql/plsql.g4
@@ -1328,7 +1328,7 @@ condition
 
 expression
     : left=expression op=IS right=is_part                                             # IsExpr
-    | left=expression NOT? op=IN '(' right+=expression (',' right+=expression)* ')'   # InExpr
+    | left=expression NOT? op=IN ( '(' subquery ')' | expression_list )               # InExpr
     | left=expression NOT? op=BETWEEN right+=expression AND right+=expression         # BetweenExpr
     | left=expression NOT? op=like_type right+=expression (ESCAPE right+=expression)? # LikeExpr
     | left=expression op=relational_operator right=expression                 # RelExpr
@@ -1351,6 +1351,7 @@ is_part
 cursor_part
     : '(' subquery ')'
     ;
+
 /*
 logical_or_expression
     : logical_and_expression

--- a/antlr_plsql/tests/v0.3.yml
+++ b/antlr_plsql/tests/v0.3.yml
@@ -21,6 +21,6 @@ code:
         #- "SELECT 1 UNION SELECT 2"
     expression:
         # bugfixes
-        - "SELECT a FROM b WHERE a IN (SELECT x FROM y)"
-        - "SELECT a FROM b WHERE a IN (1, 1 + 1)"
+        - "a IN (SELECT x FROM y)"
+        - "a IN (1, 1 + 1)"
 

--- a/antlr_plsql/tests/v0.3.yml
+++ b/antlr_plsql/tests/v0.3.yml
@@ -19,4 +19,8 @@ code:
         - "SELECT x FROM y UNION (SELECT a FROM b UNION SELECT m FROM n) ORDER BY id"
         # TODO grammar can't parse
         #- "SELECT 1 UNION SELECT 2"
+    expression:
+        # bugfixes
+        - "SELECT a FROM b WHERE a IN (SELECT x FROM y)"
+        - "SELECT a FROM b WHERE a IN (1, 1 + 1)"
 


### PR DESCRIPTION
In expressions of the form below didn't parse...

```
SELECT x FROM y WHERE x IN (SELECT a FROM b)
```

but these did

```
SELECT x FROM y WHERE x IN ((SELECT a FROM b))
```