### PR TITLE
Refactor for newest antlr-ast and ast-viewer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,5 +83,5 @@ tests/.DS_Store
 tests/dump_*.yml
 antlr_plsql/js/*
 !antlr_plsql/js/index.js
-antlr_plsql/plsql*.py
-antlr_plsql/plsql*.tokens
+antlr_plsql/antlr_py/*
+!antlr_plsql/antlr_py/__init__.py

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ buildpy:
 buildjs:
 	antlr4 -Dlanguage=JavaScript -o $(JS_DIR) antlr_plsql/plsql.g4 && mv $(JS_DIR)/antlr_plsql/* $(JS_DIR)
 
-build: buildpy buildjs
+build: buildpy
 
 clean:
 	find . \( -name \*.pyc -o -name \*.pyo -o -name __pycache__ \) -prune -exec rm -rf {} +

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
 JS_DIR=antlr_plsql/js
+PY_DIR=antlr_plsql/antlr_py
 
 .PHONY: clean
 
 all: clean test
 
 buildpy:
-	antlr4 -Dlanguage=Python3 -visitor antlr_plsql/plsql.g4
+	antlr4 -Dlanguage=Python3 -o $(PY_DIR) -visitor antlr_plsql/plsql.g4
 
 buildjs:
 	antlr4 -Dlanguage=JavaScript -o $(JS_DIR) antlr_plsql/plsql.g4 && mv $(JS_DIR)/antlr_plsql/* $(JS_DIR)

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,12 @@ PY_DIR=antlr_plsql/antlr_py
 all: clean test
 
 buildpy:
-	antlr4 -Dlanguage=Python3 -o $(PY_DIR) -visitor antlr_plsql/plsql.g4
+	antlr4 -Dlanguage=Python3 -o $(PY_DIR) -visitor antlr_plsql/plsql.g4 \
+	&& mv $(PY_DIR)/antlr_plsql/* $(PY_DIR) && rmdir $(PY_DIR)/antlr_plsql
 
 buildjs:
-	antlr4 -Dlanguage=JavaScript -o $(JS_DIR) antlr_plsql/plsql.g4 && mv $(JS_DIR)/antlr_plsql/* $(JS_DIR)
+	antlr4 -Dlanguage=JavaScript -o $(JS_DIR) antlr_plsql/plsql.g4 \
+	&& mv $(JS_DIR)/antlr_plsql/* $(JS_DIR) && rmdir $(JS_DIR)/antlr_plsql
 
 build: buildpy
 

--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ ANTLR requires Java, so we suggest you use Docker when building grammars. The `M
 
 ### Build the grammar
 
-```
+```bash
 docker build -t antlr_plsql .
 docker run -it -v ${PWD}:/usr/src/app antlr_plsql make build
 ```
 
 ### Develop
 
-```
+```bash
 docker run -it -v ${PWD}:/usr/src/app antlr_plsql /bin/bash
 
 make buildpy         # Build the grammar

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ from antlr_plsql import ast
 ast.parse("SELECT a from b")
 ```
 
+Alternatively, [use the AST viewer](https://github.com/datacamp/antlr-tsql#development).
+
 ## Travis deployment
 
 - Builds the Docker image

--- a/antlr_plsql/__init__.py
+++ b/antlr_plsql/__init__.py
@@ -1,1 +1,2 @@
-__version__ = '0.5.8'
+__version__ = '0.6.0'
+from . import antlr_py as plsql_grammar

--- a/antlr_plsql/antlr_py/__init__.py
+++ b/antlr_plsql/antlr_py/__init__.py
@@ -1,0 +1,4 @@
+from .plsqlLexer import plsqlLexer as Lexer
+from .plsqlListener import plsqlListener as Listener
+from .plsqlParser import plsqlParser as Parser
+from .plsqlVisitor import plsqlVisitor as Visitor

--- a/antlr_plsql/js/index.js
+++ b/antlr_plsql/js/index.js
@@ -1,7 +1,0 @@
-var Lexer = require('./plsqlLexer.js').plsqlLexer;
-var Parser = require('./plsqlParser.js').plsqlParser;
-
-export default {
-    Lexer,
-    Parser
-}

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,7 @@
 [pytest]
 addopts = -m "not examples"
+
+# TODO: awaiting PR
+# https://github.com/RKrahl/pytest-dependency/pull/25
+filterwarnings =
+    ignore::DeprecationWarning

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pytest==3.7.1
-antlr-ast==0.2.1
 antlr4-python3-runtime==4.7.1
+antlr-ast==0.2.1
 pyyaml==3.13
+pytest==3.8.1

--- a/setup.py
+++ b/setup.py
@@ -4,19 +4,21 @@ import re
 import ast
 from setuptools import setup
 
-_version_re = re.compile(r'__version__\s+=\s+(.*)')
+_version_re = re.compile(r"__version__\s+=\s+(.*)")
 
-with open('antlr_plsql/__init__.py', 'rb') as f:
-    version = str(ast.literal_eval(_version_re.search(
-        f.read().decode('utf-8')).group(1)))
+with open("antlr_plsql/__init__.py", "rb") as f:
+    version = str(
+        ast.literal_eval(_version_re.search(f.read().decode("utf-8")).group(1))
+    )
 
 setup(
-    name='antlr-plsql',
+    name="antlr-plsql",
     version=version,
-    packages=['antlr_plsql'],
-    install_requires=['antlr-ast', 'antlr4-python3-runtime', 'pyyaml'],
-    description='A procedural sql parser, written in Antlr4',
-    author='Michael Chow',
-    author_email='michael@datacamp.com',
-    url='https://github.com/datacamp/antlr-plsql',
-    include_package_data=True)
+    packages=["antlr_plsql"],
+    install_requires=["antlr-ast", "antlr4-python3-runtime", "pyyaml"],
+    description="A procedural sql parser, written in Antlr4",
+    author="Michael Chow",
+    author_email="michael@datacamp.com",
+    url="https://github.com/datacamp/antlr-plsql",
+    include_package_data=True,
+)

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -118,8 +118,7 @@ def test_ast_select_paren():
     assert isinstance(node, ast.SelectStmt)
 
 
-@pytest.mark.parametrize("fname", ["v0.2.yml", "v0.3.yml", "v0.5.yml"])
-def test_ast_examples_parse(fname):
+def ast_examples_parse(fname):
     import yaml
 
     dirname = os.path.dirname(__file__)
@@ -130,5 +129,12 @@ def test_ast_examples_parse(fname):
         for cmd in cmds:
             res[start].append([cmd, repr(ast.parse(cmd, start, strict=True))])
     print(res)
-    with open(dirname + "/dump_" + fname, "w") as out_f:
+    filename = "dump_" + fname
+    with open(dirname + "/" + filename, "w") as out_f:
         yaml.dump(res, out_f)
+    return filename
+
+
+@pytest.mark.parametrize("fname", ["v0.2.yml", "v0.3.yml", "v0.5.yml"])
+def test_ast_examples_parse(fname):
+    return ast_examples_parse(fname)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,6 +1,7 @@
 import pytest
 import os
 from antlr_plsql import ast
+from tests.test_ast import ast_examples_parse
 
 crnt_dir = os.path.dirname(__file__)
 examples = os.path.join(crnt_dir, "examples")
@@ -41,9 +42,9 @@ def load_dump(fname):
 @pytest.mark.parametrize(
     "start,cmd,res",
     [
-        *load_dump("dump_v0.2.yml"),
-        *load_dump("dump_v0.3.yml"),
-        *load_dump("dump_v0.5.yml"),
+        *load_dump(ast_examples_parse("v0.2.yml")),
+        *load_dump(ast_examples_parse("v0.3.yml")),
+        *load_dump(ast_examples_parse("v0.5.yml")),
     ],
 )
 def test_dump(start, cmd, res):

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -3,21 +3,48 @@ import os
 from antlr_plsql import ast
 
 crnt_dir = os.path.dirname(__file__)
-examples = os.path.join(crnt_dir, 'examples')
-#examples_sql_script = os.path.join(crnt_dir, 'examples-sql-script')
+examples = os.path.join(crnt_dir, "examples")
+# examples_sql_script = os.path.join(crnt_dir, "examples-sql-script")
+
 
 def load_examples(dir_path):
-    return [[fname, open(os.path.join(dir_path, fname)).read()] 
-                for fname in os.listdir(dir_path)
-                ]
+    return [
+        [fname, open(os.path.join(dir_path, fname)).read()]
+        for fname in os.listdir(dir_path)
+    ]
 
-@pytest.mark.examples
-@pytest.mark.parametrize('name, query', load_examples(examples))
+
+# @pytest.mark.examples
+@pytest.mark.parametrize("name, query", load_examples(examples))
 def test_examples(name, query):
     ast.parse(query)
 
-#@pytest.mark.parametrize('name, query', load_examples(examples_sql_script))
-#def test_examples_sql_script(name, query):
-#    ast.parse(query)
+
+# @pytest.mark.parametrize("name, query", load_examples(examples_sql_script))
+# def test_examples_sql_script(name, query):
+#     ast.parse(query)
 
 
+def load_dump(fname):
+    import yaml
+
+    dirname = os.path.dirname(__file__)
+    dump_data = yaml.load(open(dirname + "/" + fname))
+
+    all_cmds = []
+    for start, cmds in dump_data.items():
+        for cmd, res in cmds:
+            all_cmds.append((start, cmd, res))
+    return all_cmds
+
+
+@pytest.mark.parametrize(
+    "start,cmd,res",
+    [
+        *load_dump("dump_v0.2.yml"),
+        *load_dump("dump_v0.3.yml"),
+        *load_dump("dump_v0.5.yml"),
+    ],
+)
+def test_dump(start, cmd, res):
+    assert repr(ast.parse(cmd, start, strict=True)) == res


### PR DESCRIPTION
Use reusable functionality from antlr-ast.
Don't output JS (not needed in newest ast-viewer).
Test dump output.