### PR TITLE
[LE-696] Added concat functionality

### DIFF
--- a/antlr_plsql/plsql.g4
+++ b/antlr_plsql/plsql.g4
@@ -177,6 +177,7 @@ string_function
     | name=NVL '(' expression ',' expression ')'
     | name=TRIM '(' ((LEADING | TRAILING | BOTH)? quoted_string? FROM)? concatenation ')'
     | name=TO_DATE '(' expression (',' quoted_string)? ')'
+    | name=CONCAT '(' ( (quoted_string|expression) ',')+ (quoted_string|expression) ')'
     ;
 
 expressions
@@ -3177,6 +3178,7 @@ regular_id
     | COMPOUND
     //| CONNECT
     //| CONNECT_BY_ROOT
+    | CONCAT
     | CONSTANT
     | CONSTRAINT
     | CONSTRAINTS
@@ -3208,6 +3210,7 @@ regular_id
     | DEC
     | DECIMAL
     //| DECLARE
+    | DECODE
     | DECOMPOSE
     | DECREMENT
     //| DEFAULT
@@ -3369,6 +3372,7 @@ regular_id
     | NUMBER
     | NUMERIC
     | NVARCHAR2
+    | NVL
     | OBJECT
     //| OF
     | OFF
@@ -3484,6 +3488,7 @@ regular_id
     | SUBMULTISET
     | SUBPARTITION
     | SUBSTITUTABLE
+    | SUBSTRING
     | SUBTYPE
     | SUCCESS
     | SUSPEND
@@ -3501,6 +3506,8 @@ regular_id
     | TIMEZONE_MINUTE
     | TIMEZONE_REGION
     //| TO
+    | TO_CHAR
+    | TO_DATE
     | TRAILING
     | TRANSACTION
     | TRANSLATE
@@ -3673,6 +3680,7 @@ COMPATIBILITY:                C O M P A T I B I L I T Y;
 COMPILE:                      C O M P I L E;
 COMPOUND:                     C O M P O U N D;
 COMPRESS:                     C O M P R E S S;
+CONCAT:                       C O N C A T;
 CONNECT:                      C O N N E C T;
 CONNECT_BY_ROOT:              C O N N E C T '_' B Y '_' R O O T;
 CONSTANT:                     C O N S T A N T;

--- a/tests/examples/concat_01.sql
+++ b/tests/examples/concat_01.sql
@@ -1,0 +1,1 @@
+SELECT CONCAT('a', 'b')

--- a/tests/examples/concat_02.sql
+++ b/tests/examples/concat_02.sql
@@ -1,0 +1,1 @@
+SELECT CONCAT('a', 'b', 'c', 'd', 'e', 'f')

--- a/tests/examples/concat_03.sql
+++ b/tests/examples/concat_03.sql
@@ -1,0 +1,2 @@
+SELECT ltrim(concat(house_num, ' ', street)) AS address
+  FROM evanston311;


### PR DESCRIPTION
Added support for [LE-696]. The simplified AST mapped all arguments on the same index due to the `CONCAT` function not being in the `string_function` definition. By adding this to the definition the AST is simplified correctly.